### PR TITLE
Fix name of project in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -11,7 +11,7 @@ modification, are permitted provided that the following conditions are met:
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
 
-* Neither the name of blogongine nor the names of its
+* Neither the name of blgo nor the names of its
   contributors may be used to endorse or promote products derived from
   this software without specific prior written permission.
 


### PR DESCRIPTION
It seems that the name of the project was incorrect in the third clause in the license. Maybe you changed the name and forgot to change it there?

Also, I would encourage you to change "your.domain.name" to "example.com" in the README, as that is the convention for examples (and your.domain.name could be owned by anyone).

Sorry for the bikeshedding
