### PR TITLE
Fix go get URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Getting started
 ### Install
 
 ```
-go get http://github.com/zlowram/blgo
+go get github.com/zlowram/blgo
 ```
 
 ### Creating your site


### PR DESCRIPTION
I tried to install your project with "go get", but I got an '"http://" not allowed in import path ' error with the URL in the README, so I simply removed the "http://" from the URL and everything went well.